### PR TITLE
Wrong anchor issue in the inpage scrolling function

### DIFF
--- a/js/custom.all.js
+++ b/js/custom.all.js
@@ -118,7 +118,7 @@ jQuery(document).ready(function(){
 
 
     jQuery(".inpage_scroll_btn").click(function(event) {
-        var anchor = jQuery('.inpage_scroll_btn').attr('data-anchor');
+        var anchor = jQuery(this).attr('data-anchor');
         var offset2 = -60;
         if ( jQuery(anchor).length){
             jQuery('html, body').animate({


### PR DESCRIPTION
Issue: when there are two (or possibly more) .inpage_scroll_btn buttons on a page, clicking any of the buttons scrolled the page to the anchor of the first button (specified in data-anchor), because the anchor was taken from the first .inpage_scroll_btn element instead of the "current" one.
