### PR TITLE
Fix .parallaxonegridpinterest is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+### 2.1.8 - 07/09/2017
+**Changes:** 
+- Fixed error causing animations to not work properly on the frontpage
+
 ### 2.1.7 - 03/08/2017
 **Changes:** 
 - Fixed translation issues

--- a/js/custom.all.js
+++ b/js/custom.all.js
@@ -244,43 +244,6 @@ jQuery( document ).ready(
 	}
 );
 
-var window_width_old;
-jQuery( document ).ready(
-	function(){
-		'use strict';
-		window_width_old = jQuery( '.container' ).width();
-		if ( window_width_old <= 462 ) {
-			jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
-			jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
-		} else if ( window_width_old <= 750  ) {
-			jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
-			jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
-		} else {
-			jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 4,selector: '.product', calcMin: false} );
-			jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
-		}
-	}
-);
-
-jQuery( window ).resize(
-	function() {
-		'use strict';
-		if ( window_width_old !== jQuery( '.container' ).outerWidth() ) {
-			window_width_old = jQuery( '.container' ).outerWidth();
-			if ( window_width_old <= 462 ) {
-				jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
-				jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
-			} else if ( window_width_old <= 750  ) {
-				jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
-				jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
-			} else {
-				jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 4,selector: '.product', calcMin: false} );
-				jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
-			}
-		}
-	}
-);
-
 (function ($, window, document, undefined) {
 	'use strict';
 	var defaults = {
@@ -402,6 +365,43 @@ jQuery( window ).resize(
 			);
 		};
 })(jQuery);
+
+var window_width_old;
+jQuery( document ).ready(
+	function(){
+		'use strict';
+		window_width_old = jQuery( '.container' ).width();
+		if ( window_width_old <= 462 ) {
+			jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
+			jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
+		} else if ( window_width_old <= 750  ) {
+			jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
+			jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
+		} else {
+			jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 4,selector: '.product', calcMin: false} );
+			jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
+		}
+	}
+);
+
+jQuery( window ).resize(
+	function() {
+		'use strict';
+		if ( window_width_old !== jQuery( '.container' ).outerWidth() ) {
+			window_width_old = jQuery( '.container' ).outerWidth();
+			if ( window_width_old <= 462 ) {
+				jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
+				jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
+			} else if ( window_width_old <= 750  ) {
+				jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
+				jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 1,selector: '.product', calcMin: false} );
+			} else {
+				jQuery( '.post-type-archive-product .products' ).parallaxonegridpinterest( {columns: 4,selector: '.product', calcMin: false} );
+				jQuery( '.cart-collaterals .products' ).parallaxonegridpinterest( {columns: 2,selector: '.product', calcMin: false} );
+			}
+		}
+	}
+);
 
 var isMobile = {
 	Android: function() {


### PR DESCRIPTION
Fix the console error "Uncaught TypeError: jQuery(...).parallaxonegridpinterest is not a function" on Parallax-One/js/custom.all.js on line 259

This appeared with W3TC with js minify auto activated.

This commit just change the position of the parallaxonegridpinterest definition to prevent this function beeing called before beeing an function.